### PR TITLE
Add sorting for properties (issue #51)

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/CustomDialogCellEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/CustomDialogCellEditor.java
@@ -69,7 +69,7 @@ public class CustomDialogCellEditor extends CellEditor {
 	private static final int defaultStyle = SWT.NONE;
 
 	/**
-	 * Creates a new dialog cell editor with no control
+	 * Creates a new dialog cell editor with no control.
 	 */
 	public CustomDialogCellEditor() {
 		setStyle(defaultStyle);
@@ -102,7 +102,7 @@ public class CustomDialogCellEditor extends CellEditor {
 	}
 
 	/**
-	 * Sets the corresponding configuration parameter description
+	 * Sets the corresponding configuration parameter description.
 	 * 
 	 * @param configParamDesc
 	 *            The configuration parameter description.
@@ -279,7 +279,7 @@ public class CustomDialogCellEditor extends CellEditor {
 			return;
 		}
 
-		String text = "";//$NON-NLS-1$
+		String text = ""; //$NON-NLS-1$
 		if (value != null) {
 			text = value.toString();
 		}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/InstrumentationEditorInput.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/InstrumentationEditorInput.java
@@ -44,7 +44,7 @@ public class InstrumentationEditorInput extends AbstractSpotterEditorInput {
 	 * @param file
 	 *            the associated file.
 	 */
-	public InstrumentationEditorInput(IFile file) throws IllegalArgumentException {
+	public InstrumentationEditorInput(IFile file) {
 		super(file);
 		MeasurementEnvironmentFactory factory = MeasurementEnvironmentFactory.getInstance();
 		XMeasurementEnvironment measurementEnv;

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/MeasurementEditorInput.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/MeasurementEditorInput.java
@@ -43,10 +43,8 @@ public class MeasurementEditorInput extends AbstractSpotterEditorInput {
 	 * 
 	 * @param file
 	 *            the associated file.
-	 * @throws IllegalArgumentException
-	 *             when there's a problem creating the input from the given file
 	 */
-	public MeasurementEditorInput(IFile file) throws IllegalArgumentException {
+	public MeasurementEditorInput(IFile file) {
 		super(file);
 		MeasurementEnvironmentFactory factory = MeasurementEnvironmentFactory.getInstance();
 		XMeasurementEnvironment measurementEnv;

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/NumberValidator.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/NumberValidator.java
@@ -85,7 +85,8 @@ public class NumberValidator implements ICellEditorValidator {
 					break;
 				}
 			}
-		} catch (Exception e) {
+		} catch (NumberFormatException e) {
+			errorMsg += " Unable to parse the input.";
 		}
 		if (errorMsg != null && errorMsgBoundAppend != null) {
 			errorMsg = errorMsg + errorMsgBoundAppend;

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/SpotterConfigEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/SpotterConfigEditor.java
@@ -31,12 +31,13 @@ import org.spotter.eclipse.ui.editors.factory.ElementFactory;
 import org.spotter.eclipse.ui.model.ExtensionItem;
 import org.spotter.eclipse.ui.model.xml.IModelWrapper;
 import org.spotter.eclipse.ui.model.xml.SpotterConfigModelWrapper;
+import org.spotter.eclipse.ui.util.DialogUtils;
 import org.spotter.eclipse.ui.util.SpotterProjectSupport;
 import org.spotter.eclipse.ui.viewers.PropertiesGroupViewer;
 import org.spotter.shared.environment.model.XMConfiguration;
 
 /**
- * An editor to edit Spotter properties.
+ * An editor to edit DynamicSpotter configuration properties.
  * 
  * @author Denis Knoepfle
  * 
@@ -79,7 +80,7 @@ public class SpotterConfigEditor extends AbstractSpotterEditor {
 
 			super.doSave(monitor);
 		} catch (Exception e) {
-			MessageDialog.openError(null, TITLE_ERR_DIALOG, ERR_MSG_SAVE + e.getMessage());
+			DialogUtils.openError(TITLE_ERR_DIALOG, ERR_MSG_SAVE + e.getMessage());
 		}
 	}
 
@@ -128,7 +129,7 @@ public class SpotterConfigEditor extends AbstractSpotterEditor {
 			return null;
 		}
 
-		wrapper = new SpotterConfigModelWrapper(file.getProject().getName(), properties, true);
+		wrapper = new SpotterConfigModelWrapper(file.getProject().getName(), properties);
 		ExtensionItem inputModel = new ExtensionItem(wrapper);
 		inputModel.setIgnoreConnection(true);
 

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/WorkloadEditorInput.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/WorkloadEditorInput.java
@@ -35,7 +35,7 @@ public class WorkloadEditorInput extends AbstractSpotterEditorInput {
 
 	private static final String NAME = "Workload Satellite Adapter";
 	private static final String IMAGE_PATH = SpotterProjectConfigWorkload.IMAGE_PATH;
-	
+
 	private List<XMeasurementEnvObject> workloadAdapters;
 
 	/**
@@ -43,10 +43,8 @@ public class WorkloadEditorInput extends AbstractSpotterEditorInput {
 	 * 
 	 * @param file
 	 *            the associated file.
-	 * @throws IllegalArgumentException
-	 *             when there's a problem creating the input from the given file
 	 */
-	public WorkloadEditorInput(IFile file) throws IllegalArgumentException {
+	public WorkloadEditorInput(IFile file) {
 		super(file);
 		MeasurementEnvironmentFactory factory = MeasurementEnvironmentFactory.getInstance();
 		XMeasurementEnvironment measurementEnv;

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/SpotterConfigModelWrapper.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/SpotterConfigModelWrapper.java
@@ -16,7 +16,6 @@
 package org.spotter.eclipse.ui.model.xml;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -48,21 +47,6 @@ public class SpotterConfigModelWrapper implements IModelWrapper {
 	 *            the properties of the model
 	 */
 	public SpotterConfigModelWrapper(String projectName, Properties properties) {
-		this(projectName, properties, false);
-	}
-
-	/**
-	 * Creates an instance of this class using the given properties.
-	 * 
-	 * @param projectName
-	 *            the project name
-	 * @param properties
-	 *            the properties of the model
-	 * @param sortAscending
-	 *            true, to sort the configuration keys (alphabetically)
-	 *            ascending
-	 */
-	public SpotterConfigModelWrapper(String projectName, Properties properties, boolean sortAscending) {
 		this.projectName = projectName;
 		this.xmConfigList = new ArrayList<XMConfiguration>();
 		for (Entry<Object, Object> entry : properties.entrySet()) {
@@ -70,10 +54,6 @@ public class SpotterConfigModelWrapper implements IModelWrapper {
 			xmConfig.setKey((String) entry.getKey());
 			xmConfig.setValue((String) entry.getValue());
 			xmConfigList.add(xmConfig);
-		}
-
-		if (sortAscending) {
-			Collections.sort(xmConfigList);
 		}
 	}
 

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/providers/PropertiesContentProvider.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/providers/PropertiesContentProvider.java
@@ -16,7 +16,6 @@
 package org.spotter.eclipse.ui.providers;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jface.viewers.AbstractTableViewer;
@@ -74,11 +73,8 @@ public class PropertiesContentProvider implements IStructuredContentProvider, II
 		}
 		ExtensionItem tableItem = (ExtensionItem) inputElement;
 		IModelWrapper modelWrapper = tableItem.getModelWrapper();
-		List<AbstractPropertyItem> mandatoryConfigItems = new ArrayList<AbstractPropertyItem>();
-		List<AbstractPropertyItem> nonMandatoryConfigItems = new ArrayList<AbstractPropertyItem>();
+		List<AbstractPropertyItem> configItems = new ArrayList<>();
 		List<XMConfiguration> xmConfigList = modelWrapper.getConfig();
-
-		Collections.sort(xmConfigList);
 		
 		int size = xmConfigList == null ? 0 : xmConfigList.size();
 		Object[] result = new Object[size];
@@ -86,22 +82,12 @@ public class PropertiesContentProvider implements IStructuredContentProvider, II
 		if (xmConfigList != null) {
 			for (XMConfiguration xmConfig : xmConfigList) {
 				ConfigParameterDescription desc = tableItem.getExtensionConfigParam(xmConfig.getKey());
-				AbstractPropertyItem configParam = new ConfigParamPropertyItem(modelWrapper, desc, xmConfig);
-				if (desc.isMandatory()) {
-					mandatoryConfigItems.add(configParam);
-				} else {
-					nonMandatoryConfigItems.add(configParam);
+				if (desc != null) {
+					configItems.add(new ConfigParamPropertyItem(modelWrapper, desc, xmConfig));
 				}
 			}
 
-			int index = 0;
-			Object[] configItems = mandatoryConfigItems.toArray();
-			System.arraycopy(configItems, 0, result, index, configItems.length);
-			index += configItems.length;
-
-			configItems = nonMandatoryConfigItems.toArray();
-			System.arraycopy(configItems, 0, result, index, configItems.length);
-			index += configItems.length;
+			result = configItems.toArray(result);
 		}
 
 		return result;


### PR DESCRIPTION
Added viewer comparator to properties viewer. Elements are sorted
alphabetically now according to their displayed name, so changes to that
affect the order. Whether the sorter prioritizes mandatory-flagged
properties can be toggled via the name-column (click), by default it's
turned off.

Change-Id: I1768a0e02242fb1946e414bb563904c9731fb948
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
