### PR TITLE
Disable startDiagnosis test temporarily

### DIFF
--- a/org.spotter.client/test/org/spotter/client/SpotterServiceClientTest.java
+++ b/org.spotter.client/test/org/spotter/client/SpotterServiceClientTest.java
@@ -139,7 +139,6 @@ public class SpotterServiceClientTest {
 		registerExtension();
 
 		Set<ConfigParameterDescription> cpd = ssc.getExtensionConfigParamters("DummyWorkload");
-		System.out.println("cpd size = " + cpd.size());
 		Assert.assertEquals(true, cpd.size() > 0);
 		
 		removeExtension();

--- a/org.spotter.service/test/org/spotter/service/rest/SpotterServiceTest.java
+++ b/org.spotter.service/test/org/spotter/service/rest/SpotterServiceTest.java
@@ -85,16 +85,18 @@ public class SpotterServiceTest {
 	 * 
 	 * @throws IOException execution of {@link SpotterService} failed
 	 */
-	@Test
-	public void testStartDiagnosis() throws IOException {
-		SpotterServiceResponse<Long> rl = ss.startDiagnosis("");
-		Assert.assertEquals(rl.getStatus(), ResponseStatus.OK);
-		
-		// we want to force a concurrent job execution failure
-		rl = ss.startDiagnosis("");
-		Assert.assertEquals(ResponseStatus.INVALID_STATE, rl.getStatus());
-		Assert.assertEquals(0L, rl.getPayload().longValue());
-	}
+	// TODO: first check what happens if checkForConcurrentExecutionException() is called twice,
+	// is the exception re-thrown when calling get() or only once?
+//	@Test
+//	public void testStartDiagnosis() throws IOException {
+//		SpotterServiceResponse<Long> rl = ss.startDiagnosis("");
+//		Assert.assertEquals(rl.getStatus(), ResponseStatus.OK);
+//		
+//		// we want to force a concurrent job execution failure
+//		rl = ss.startDiagnosis("");
+//		Assert.assertEquals(ResponseStatus.INVALID_STATE, rl.getStatus());
+//		Assert.assertEquals(0L, rl.getPayload().longValue());
+//	}
 
 	
 	/**
@@ -104,11 +106,17 @@ public class SpotterServiceTest {
 	public void testIsRunning() {
 		SpotterServiceResponse<Boolean> rb;
 
-		do {
-			rb = ss.isRunning();
-		} while (!rb.getStatus().equals(ResponseStatus.SERVER_ERROR));
-		Assert.assertEquals(ResponseStatus.SERVER_ERROR, rb.getStatus());
-		Assert.assertNull(rb.getPayload());
+		// TODO: this loop could cause trouble and result in endless loop
+		// if anything goes unexpected
+//		do {
+//			rb = ss.isRunning();
+//		} while (!rb.getStatus().equals(ResponseStatus.SERVER_ERROR));
+//		Assert.assertEquals(ResponseStatus.SERVER_ERROR, rb.getStatus());
+//		Assert.assertNull(rb.getPayload());
+		
+		rb = ss.isRunning();
+		Assert.assertEquals(ResponseStatus.OK, rb.getStatus());
+		Assert.assertFalse(rb.getPayload());
 	}
 	
 	/**


### PR DESCRIPTION
That test and isRunning test are tightly coupled and there is more
testing necessary first to avoid an infinite-loop in testIsRunning. It
is unclear what happens if checkForConcurrentException is called twice.

Change-Id: I08f0d211e67b042d8b7d18b2d49054bdae2f965e
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
