### PR TITLE
Enhance fetching of results and other minor improvements

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/ServiceClientWrapper.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/ServiceClientWrapper.java
@@ -15,6 +15,7 @@
  */
 package org.spotter.eclipse.ui;
 
+import java.io.InputStream;
 import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,7 +37,6 @@ import org.spotter.shared.configuration.JobDescription;
 import org.spotter.shared.configuration.SpotterExtensionType;
 import org.spotter.shared.hierarchy.model.RawHierarchyFactory;
 import org.spotter.shared.hierarchy.model.XPerformanceProblem;
-import org.spotter.shared.result.model.ResultsContainer;
 import org.spotter.shared.status.SpotterProgress;
 
 import com.sun.jersey.api.client.ClientHandlerException;
@@ -248,9 +248,10 @@ public class ServiceClientWrapper {
 	 * 
 	 * @param jobId
 	 *            the job id of the diagnosis run
-	 * @return the retrieved results container or <code>null</code> if none
+	 * @return input stream containing the zipped run result folder or
+	 *         <code>null</code> if none found
 	 */
-	public ResultsContainer requestResults(final String jobId) {
+	public InputStream requestResults(final String jobId) {
 		lastException = null;
 		try {
 			return client.requestResults(jobId);

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/providers/NavigatorContentProvider.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/providers/NavigatorContentProvider.java
@@ -349,7 +349,7 @@ public class NavigatorContentProvider implements ITreeContentProvider, IResource
 	public void resourceChanged(IResourceChangeEvent event) {
 		UIJob uiJob = new UIJob("refresh Project Navigator") { //$NON-NLS-1$
 			public IStatus runInUIThread(IProgressMonitor monitor) {
-				if (viewer != null && !viewer.getControl().isDisposed()) {
+				if (viewer != null && !viewer.getControl().isDisposed() && !viewer.isBusy()) {
 					TreePath[] treePaths = viewer.getExpandedTreePaths();
 					viewer.refresh();
 					viewer.setExpandedTreePaths(treePaths);

--- a/org.spotter.service/src/org/spotter/service/rest/SpotterService.java
+++ b/org.spotter.service/src/org/spotter/service/rest/SpotterService.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.StreamingOutput;
 
 import org.lpe.common.config.ConfigParameterDescription;
 import org.slf4j.Logger;
@@ -34,7 +35,6 @@ import org.spotter.shared.configuration.ConfigKeys;
 import org.spotter.shared.configuration.JobDescription;
 import org.spotter.shared.configuration.SpotterExtensionType;
 import org.spotter.shared.hierarchy.model.XPerformanceProblem;
-import org.spotter.shared.result.model.ResultsContainer;
 import org.spotter.shared.service.ResponseStatus;
 import org.spotter.shared.service.SpotterServiceResponse;
 import org.spotter.shared.status.SpotterProgress;
@@ -86,20 +86,20 @@ public class SpotterService {
 	 *            the job id matching to the diagnosis run to fetch the results of
 	 * @return the results container for the given id or <code>null</code> if for the id no results exist
 	 */
-	@GET
-	@Path(ConfigKeys.SPOTTER_REST_REQU_RESULTS + "/{jobId}")
-	@Produces(MediaType.APPLICATION_JSON)
-	public SpotterServiceResponse<ResultsContainer> requestResults(@PathParam("jobId") String jobId) {
-		try {
-			ResultsContainer container = SpotterServiceWrapper.getInstance().requestResults(jobId);
-			if (jobId == null) {
-				return new SpotterServiceResponse<ResultsContainer>(null, ResponseStatus.INVALID_STATE);
-			} else {
-				return new SpotterServiceResponse<ResultsContainer>(container, ResponseStatus.OK);
-			}
-		} catch (Exception e) {
-			return createErrorResponse(e);
+	@POST
+	@Path(ConfigKeys.SPOTTER_REST_REQU_RESULTS)
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces("application/zip")
+	public StreamingOutput requestResults(String jobId) {
+		if (jobId == null) {
+			return null;
 		}
+		try {
+			return SpotterServiceWrapper.getInstance().requestResults(jobId);
+		} catch (Exception e) {
+			LOGGER.error("Server error: " + e);
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Now resources like images etc. will also be fetched, raw data is
ignored.

Improved the loading process of result items in the navigator. The
loading of the items will now be deferred and performed in the
background, so that the user has a quicker feedback when expanding the
project node for the first time.

When run results nodes are already displaying but their data has been
deleted for some reason, it will be automatically refetched before
trying to access the files. This only counts for the whole folder,
single files won't be checked.

Change-Id: I8d300c0e30f1bde3c4bb68e81c6ac667e8fcde04
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
