### PR TITLE
Fix correct usage of ISelectionService and ISelectionProvider

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractExtensionsEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractExtensionsEditor.java
@@ -103,6 +103,7 @@ public abstract class AbstractExtensionsEditor extends AbstractSpotterEditor {
 		propertiesGroupViewer = new PropertiesGroupViewer(container, this);
 
 		extensionsGroupViewer.setPropertiesGroupViewer(propertiesGroupViewer);
+		getSite().setSelectionProvider(extensionsGroupViewer);
 
 		// define proportioning of configured components and properties group
 		container.setWeights(new int[] { 1, 2 });

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/handlers/DeleteHandler.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/handlers/DeleteHandler.java
@@ -23,14 +23,8 @@ import java.util.Map;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.ui.IWorkbenchPartReference;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.menus.UIElement;
-import org.eclipse.ui.navigator.CommonViewer;
-import org.spotter.eclipse.ui.Activator;
 import org.spotter.eclipse.ui.navigator.IDeletable;
 import org.spotter.eclipse.ui.util.SpotterUtils;
 
@@ -55,14 +49,7 @@ public class DeleteHandler extends AbstractHandler implements IElementUpdater {
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		String activePartId = null;
-		if (window != null) {
-			IWorkbenchPartReference partRef = window.getPartService().getActivePartReference();
-			activePartId = partRef == null ? null : partRef.getId();
-		}
-		
-		Iterator<?> iter = getSelectionIterator(activePartId);
+		Iterator<?> iter = SpotterUtils.getActiveWindowStructuredSelectionIterator();
 		if (iter == null) {
 			return null;
 		}
@@ -107,8 +94,7 @@ public class DeleteHandler extends AbstractHandler implements IElementUpdater {
 
 	private List<IDeletable> getSelectedDeletables() {
 		List<IDeletable> deletables = new ArrayList<>();
-
-		Iterator<?> iter = getSelectionIterator("foo.missing.id"); // TODO: give real id here
+		Iterator<?> iter = SpotterUtils.getActiveWindowStructuredSelectionIterator();
 		if (iter == null) {
 			return deletables;
 		}
@@ -137,21 +123,6 @@ public class DeleteHandler extends AbstractHandler implements IElementUpdater {
 			}
 		}
 		return deletables;
-	}
-
-	private Iterator<?> getSelectionIterator(String partId) {
-		if (partId == null) {
-			return null;
-		}
-		
-		Activator activator = Activator.getDefault();
-		CommonViewer viewer = activator.getNavigatorViewer();
-		if (viewer == null) {
-			return null;
-		}
-
-		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
-		return selection.isEmpty() ? null : selection.iterator();
 	}
 
 }

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/handlers/DuplicateHandler.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/handlers/DuplicateHandler.java
@@ -20,9 +20,8 @@ import java.util.Iterator;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.ui.navigator.CommonViewer;
-import org.spotter.eclipse.ui.Activator;
 import org.spotter.eclipse.ui.navigator.IDuplicatable;
 import org.spotter.eclipse.ui.util.SpotterUtils;
 
@@ -43,14 +42,11 @@ public class DuplicateHandler extends AbstractHandler {
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		Activator activator = Activator.getDefault();
-		CommonViewer viewer = activator.getNavigatorViewer();
-		if (viewer == null) {
+		Iterator<?> iter = SpotterUtils.getActiveWindowStructuredSelectionIterator();
+		if (iter == null) {
 			return null;
 		}
-
-		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
-		Iterator<?> iter = selection.iterator();
+		
 		while (iter.hasNext()) {
 			SpotterUtils.duplicateNavigatorElement(iter.next());
 		}
@@ -65,19 +61,18 @@ public class DuplicateHandler extends AbstractHandler {
 	 */
 	@Override
 	public boolean isEnabled() {
-		Activator activator = Activator.getDefault();
-		CommonViewer viewer = activator.getNavigatorViewer();
-		if (viewer == null) {
+		ISelection selection = SpotterUtils.getActiveWindowSelection();
+		if (!(selection instanceof IStructuredSelection)) {
 			return false;
 		}
 
-		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
-		if (selection.size() != 1) {
+		IStructuredSelection structSelection = (IStructuredSelection) selection;
+		if (structSelection.size() != 1) {
 			return false;
 		}
 
 		// check if selected element is duplicatable
-		Object element = selection.iterator().next();
+		Object element = structSelection.getFirstElement();
 		boolean isDuplicatable = (element instanceof IDuplicatable);
 
 		return isDuplicatable;

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/handlers/OpenHandler.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/handlers/OpenHandler.java
@@ -20,9 +20,6 @@ import java.util.Iterator;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.TreeViewer;
-import org.spotter.eclipse.ui.Activator;
 import org.spotter.eclipse.ui.navigator.IOpenableProjectElement;
 import org.spotter.eclipse.ui.util.SpotterUtils;
 
@@ -41,14 +38,11 @@ public class OpenHandler extends AbstractHandler {
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		Activator activator = Activator.getDefault();
-		TreeViewer viewer = activator.getNavigatorViewer();
-		if (viewer == null) {
+		Iterator<?> iter = SpotterUtils.getActiveWindowStructuredSelectionIterator();
+		if (iter == null) {
 			return null;
 		}
 
-		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
-		Iterator<?> iter = selection.iterator();
 		while (iter.hasNext()) {
 			SpotterUtils.openNavigatorElement(iter.next());
 		}
@@ -64,17 +58,10 @@ public class OpenHandler extends AbstractHandler {
 	 */
 	@Override
 	public boolean isEnabled() {
-		Activator activator = Activator.getDefault();
-		TreeViewer viewer = activator.getNavigatorViewer();
-		if (viewer == null) {
+		Iterator<?> iter = SpotterUtils.getActiveWindowStructuredSelectionIterator();
+		if (iter == null) {
 			return false;
 		}
-
-		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
-		if (selection.isEmpty()) {
-			return false;
-		}
-		Iterator<?> iter = selection.iterator();
 
 		while (iter.hasNext()) {
 			if (!(iter.next() instanceof IOpenableProjectElement)) {

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/util/SpotterUtils.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/util/SpotterUtils.java
@@ -17,12 +17,17 @@ package org.spotter.eclipse.ui.util;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.bind.JAXBException;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spotter.eclipse.ui.Activator;
@@ -169,6 +174,44 @@ public final class SpotterUtils {
 		}
 
 		Activator.getDefault().getNavigatorViewer().refresh();
+	}
+
+	/**
+	 * Returns the active workbench window's current selection if there exists
+	 * an active window. The selection may be <code>null</code> or empty.
+	 * <p>
+	 * Using the window's <code>ISelectionService</code> this method only
+	 * retrieves selections that stem from a previously set
+	 * <code>ISelectionProvider</code> in any of the window's parts.
+	 * </p>
+	 * 
+	 * @return the selection or <code>null</code> if none
+	 */
+	public static ISelection getActiveWindowSelection() {
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		return window == null ? null : window.getSelectionService().getSelection();
+	}
+
+	/**
+	 * Returns an iterator over the active workbench window's current selection
+	 * if there exists an active window which contains a non-empty
+	 * <code>IStructuredSelection</code>.
+	 * <p>
+	 * Using the window's <code>ISelectionService</code> this method only
+	 * retrieves selections that stem from a previously set
+	 * <code>ISelectionProvider</code> in any of the window's parts.
+	 * </p>
+	 * 
+	 * @return iterator over a non-empty selection or <code>null</code> if none
+	 */
+	public static Iterator<?> getActiveWindowStructuredSelectionIterator() {
+		ISelection selection = getActiveWindowSelection();
+
+		if (selection instanceof IStructuredSelection) {
+			return selection.isEmpty() ? null : ((IStructuredSelection) selection).iterator();
+		} else {
+			return null;
+		}
 	}
 
 	/**

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/viewers/ExtensionsGroupViewer.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/viewers/ExtensionsGroupViewer.java
@@ -25,7 +25,9 @@ import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -83,7 +85,7 @@ import org.spotter.shared.environment.model.XMConfiguration;
  * @author Denis Knoepfle
  * 
  */
-public class ExtensionsGroupViewer {
+public class ExtensionsGroupViewer implements ISelectionProvider {
 
 	private static final int VIEWER_CONTROL_STYLE = SWT.BORDER | SWT.SINGLE | SWT.FULL_SELECTION | SWT.H_SCROLL
 			| SWT.V_SCROLL;
@@ -162,6 +164,26 @@ public class ExtensionsGroupViewer {
 	 */
 	public void setFocus() {
 		viewerControl.setFocus();
+	}
+
+	@Override
+	public void addSelectionChangedListener(ISelectionChangedListener listener) {
+		extensionsViewer.addSelectionChangedListener(listener);
+	}
+
+	@Override
+	public ISelection getSelection() {
+		return extensionsViewer.getSelection();
+	}
+
+	@Override
+	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
+		extensionsViewer.removeSelectionChangedListener(listener);
+	}
+
+	@Override
+	public void setSelection(ISelection selection) {
+		extensionsViewer.setSelection(selection);
 	}
 
 	/**
@@ -346,7 +368,7 @@ public class ExtensionsGroupViewer {
 			extensionsViewer.setSelection(new StructuredSelection(lastAdded));
 			editor.markDirty();
 		}
-		
+
 		if (previousFocusControl != null && !previousFocusControl.isFocusControl()) {
 			previousFocusControl.forceFocus();
 		}


### PR DESCRIPTION
Adjusted to Eclipse' regular handling of providing and accessing
selections within the workbench. This fix also prepares for easier reuse
of commands in context menu for the extensions viewer (preparations for
changes for #101).

Change-Id: If3c356633e8a9ef67bfae271a7380349819d2209
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
