### PR TITLE
Fix bug with hierarchy editor input (issue #142)

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractSpotterEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractSpotterEditor.java
@@ -273,7 +273,7 @@ public abstract class AbstractSpotterEditor extends EditorPart {
 				applicableOrRepaired = false;
 			}
 		}
-		
+
 		String projectName = containedFile.getProject().getName();
 		dialogQuestion = String.format(dialogQuestion, containedFile.getLocation(), projectName);
 		if (!applicableOrRepaired && DialogUtils.openConfirm(TITLE_INPUT_INVALID, dialogQuestion)) {

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/HierarchyEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/HierarchyEditor.java
@@ -124,7 +124,9 @@ public class HierarchyEditor extends AbstractExtensionsEditor {
 
 	@Override
 	protected void makeInputApplicable(AbstractSpotterEditorInput input) throws UICoreException {
-		XPerformanceProblem problem = Activator.getDefault().getClient(getProject().getName()).getDefaultHierarchy();
+		String projectName = input.getProject().getName();
+		XPerformanceProblem problem = Activator.getDefault().getClient(projectName).getDefaultHierarchy();
+
 		SpotterProjectSupport.saveHierarchy(input.getFile(), problem);
 	}
 

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ActiveRunView.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ActiveRunView.java
@@ -216,7 +216,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 			clear();
 		}
 
-		WidgetUtils.submitSyncExec(display, new Runnable() {
+		WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 			@Override
 			public void run() {
 				setContentDescription(description);
@@ -240,7 +240,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 		}
 
 		if (!hasClientConnection || hasConnectionErrorOccured) {
-			WidgetUtils.submitSyncExec(display, new Runnable() {
+			WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 				@Override
 				public void run() {
 					label.setText("No connection to DS service. Try again later.");
@@ -248,7 +248,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 			});
 		} else if (jobId == null) {
 			clear();
-			WidgetUtils.submitSyncExec(display, new Runnable() {
+			WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 				@Override
 				public void run() {
 					label.setText("Currently no running diagnosis.");
@@ -257,7 +257,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 		} else {
 			updateDiagnosisData(jobId, client, projectName);
 		}
-		WidgetUtils.submitSyncExec(display, new Runnable() {
+		WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 			@Override
 			public void run() {
 				label.getParent().layout();
@@ -271,7 +271,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 			XPerformanceProblem rootProblem = client.getCurrentRootProblem(false);
 			if (rootProblem == null) {
 				LOGGER.warn("Cannot fetch root problem!", client.getLastClientException());
-				WidgetUtils.submitSyncExec(display, new Runnable() {
+				WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 					@Override
 					public void run() {
 						label.setText("Cannot fetch root problem!");
@@ -282,7 +282,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 			}
 			final IExtensionItem input = HierarchyEditor.createPerformanceProblemHierarchy(projectName,
 					extensionItemFactory, rootProblem);
-			WidgetUtils.submitSyncExec(display, new Runnable() {
+			WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 				@Override
 				public void run() {
 					treeViewer.setInput(input);
@@ -294,7 +294,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 		spotterProgress = client.getCurrentProgressReport();
 		runExtensionsImageProvider.setSpotterProgress(spotterProgress);
 
-		WidgetUtils.submitSyncExec(display, new Runnable() {
+		WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 			@Override
 			public void run() {
 				label.setText("Diagnosis with job id '" + jobId + "' is in progress!");
@@ -304,7 +304,7 @@ public class ActiveRunView extends ViewPart implements ISelectionChangedListener
 	}
 
 	private void clear() {
-		WidgetUtils.submitSyncExec(display, new Runnable() {
+		WidgetUtils.submitSyncExecIgnoreDisposed(display, new Runnable() {
 			@Override
 			public void run() {
 				label.setText("");


### PR DESCRIPTION
The makeInputApplicable() method tried to access getProject() before the
init() method of the Hierarchy Editor set the input, thus it always
returned null. Now using given input to retrieve project instead.

Change-Id: Ie5267df11bfbd4281b17ac152a0271de4fd9aaf4
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
