### PR TITLE
Fix bug in ViewUpdater where hierarchy tree was not fetched again

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ActiveRunView.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ActiveRunView.java
@@ -298,6 +298,7 @@ public class ActiveRunView extends ViewPart {
 			public void run() {
 				label.setText("");
 				treeViewer.setInput(null);
+				currentViewerInputJobId = 0;
 			}
 		});
 	}


### PR DESCRIPTION
Needed to reset the currently saved job id in the view, so that the
hierarchy tree is fetched again.

Change-Id: I0527672491a7da9fd6e0611065aae484280a17b2
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
