### PR TITLE
Prepare for Drag 'n Drop support within editors

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/dnd/ExtensionDragListener.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/dnd/ExtensionDragListener.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2014 SAP AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spotter.eclipse.ui.dnd;
+
+import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DragSourceEvent;
+import org.eclipse.swt.dnd.DragSourceListener;
+
+/**
+ * A drag listener for {@link org.spotter.eclipse.ui.model.IExtensionItem}.
+ * 
+ * @author Denis Knoepfle
+ * 
+ */
+public class ExtensionDragListener implements DragSourceListener {
+
+	private final StructuredViewer viewer;
+
+	/**
+	 * Creates a new drag listener for the given viewer.
+	 * 
+	 * @param viewer
+	 *            the viewer this listener is attached to
+	 */
+	public ExtensionDragListener(StructuredViewer viewer) {
+		this.viewer = viewer;
+	}
+
+	@Override
+	public void dragStart(DragSourceEvent event) {
+		event.doit = !viewer.getSelection().isEmpty();
+		if (event.doit) {
+			LocalSelectionTransfer.getTransfer().setSelection(viewer.getSelection());
+		}
+	}
+
+	@Override
+	public void dragSetData(DragSourceEvent event) {
+		// nothing to do as we use LocalSelectionTransfer
+	}
+
+	@Override
+	public void dragFinished(DragSourceEvent event) {
+		if (!event.doit || event.detail == DND.DROP_NONE) {
+			return;
+		}
+		
+		//if (event.detail == DND.DROP_MOVE) {
+			// TODO: remove the drag source from the model
+		//}
+	}
+
+}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/dnd/ExtensionDropListener.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/dnd/ExtensionDropListener.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2014 SAP AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spotter.eclipse.ui.dnd;
+
+import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerDropAdapter;
+import org.eclipse.swt.dnd.TransferData;
+import org.spotter.eclipse.ui.model.IExtensionItem;
+
+/**
+ * A drop listener for {@link IExtensionItem}.
+ * 
+ * @author Denis Knoepfle
+ * 
+ */
+public class ExtensionDropListener extends ViewerDropAdapter {
+
+	private final String acceptableEditorId;
+
+	/**
+	 * Creates a new drop listener associated with the given viewer which
+	 * accepts elements that suit the specified editor.
+	 * 
+	 * @param viewer
+	 *            the viewer this listener is attached to
+	 * @param acceptableEditorId
+	 *            the id of the editor which will be accepted. Must not be
+	 *            <code>null</code>.
+	 */
+	public ExtensionDropListener(Viewer viewer, String acceptableEditorId) {
+		super(viewer);
+		if (acceptableEditorId == null) {
+			throw new IllegalArgumentException("acceptableEditorId must not be null");
+		}
+		this.acceptableEditorId = acceptableEditorId;
+	}
+
+	@Override
+	public boolean performDrop(Object data) {
+		// int location = getCurrentLocation();
+		Object target = getCurrentTarget();
+
+		IExtensionItem extension = getExtension(target);
+		if (extension != null) {
+			System.out.println("Dropped '" + extension + "' to target '" + target + "'");
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean validateDrop(Object target, int operation, TransferData transferType) {
+		boolean isSupported = LocalSelectionTransfer.getTransfer().isSupportedType(transferType);
+		return isSupported && getExtension(target) != null;
+	}
+
+	private IExtensionItem getExtension(Object target) {
+		ISelection selection = LocalSelectionTransfer.getTransfer().getSelection();
+		IExtensionItem extension = null;
+		if (selection instanceof IStructuredSelection && !selection.isEmpty()) {
+			Object element = ((IStructuredSelection) selection).getFirstElement();
+			if (element instanceof IExtensionItem && !element.equals(target)) {
+				extension = (IExtensionItem) element;
+				if (!acceptableEditorId.equals(extension.getEditorId())) {
+					extension = null;
+				}
+			}
+		}
+
+		return extension;
+	}
+}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractEnvironmentEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractEnvironmentEditor.java
@@ -67,7 +67,7 @@ public abstract class AbstractEnvironmentEditor extends AbstractExtensionsEditor
 	@Override
 	public IExtensionItem getInitialExtensionsInput() {
 		List<XMeasurementEnvObject> envObjects = getMeasurementEnvironmentObjects();
-		IExtensionItemFactory factory = new BasicEditorExtensionItemFactory();
+		IExtensionItemFactory factory = new BasicEditorExtensionItemFactory(getEditorId());
 		IExtensionItem input = factory.createExtensionItem();
 
 		String projectName = getProject().getName();

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractExtensionsEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractExtensionsEditor.java
@@ -97,7 +97,7 @@ public abstract class AbstractExtensionsEditor extends AbstractSpotterEditor {
 		SashForm container = new SashForm(parent, SWT.VERTICAL | SWT.SMOOTH);
 
 		// first part: configured components group
-		extensionsGroupViewer = new ExtensionsGroupViewer(container, this, supportsHierarchicalExtensionItems());
+		extensionsGroupViewer = new ExtensionsGroupViewer(container, this, supportsHierarchicalExtensionItems(), true);
 
 		// second part: properties group
 		propertiesGroupViewer = new PropertiesGroupViewer(container, this);

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractSpotterEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractSpotterEditor.java
@@ -77,6 +77,11 @@ public abstract class AbstractSpotterEditor extends EditorPart {
 	 * @return The name of the editor
 	 */
 	protected abstract String getEditorName();
+	
+	/**
+	 * @return The id of the editor
+	 */
+	public abstract String getEditorId();
 
 	/**
 	 * Implementing editors should create a suitable editor input and return it.

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/HierarchyEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/HierarchyEditor.java
@@ -63,6 +63,11 @@ public class HierarchyEditor extends AbstractExtensionsEditor {
 	protected String getEditorName() {
 		return EDITOR_NAME;
 	}
+	
+	@Override
+	public String getEditorId() {
+		return ID;
+	}
 
 	@Override
 	public void doSave(IProgressMonitor monitor) {
@@ -83,7 +88,7 @@ public class HierarchyEditor extends AbstractExtensionsEditor {
 		}
 
 		String projectName = getProject().getName();
-		IExtensionItemFactory factory = new BasicEditorExtensionItemFactory();
+		IExtensionItemFactory factory = new BasicEditorExtensionItemFactory(getEditorId());
 		return createPerformanceProblemHierarchy(projectName, factory, problemRoot);
 	}
 

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/InstrumentationEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/InstrumentationEditor.java
@@ -45,6 +45,11 @@ public class InstrumentationEditor extends AbstractEnvironmentEditor {
 	protected String getEditorName() {
 		return EDITOR_NAME;
 	}
+	
+	@Override
+	public String getEditorId() {
+		return ID;
+	}
 
 	@Override
 	protected void applyChanges(Object xmlModelRoot) {

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/MeasurementEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/MeasurementEditor.java
@@ -45,6 +45,11 @@ public class MeasurementEditor extends AbstractEnvironmentEditor {
 	protected String getEditorName() {
 		return EDITOR_NAME;
 	}
+	
+	@Override
+	public String getEditorId() {
+		return ID;
+	}
 
 	@Override
 	protected void applyChanges(Object xmlModelRoot) {

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/SpotterConfigEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/SpotterConfigEditor.java
@@ -59,6 +59,11 @@ public class SpotterConfigEditor extends AbstractSpotterEditor {
 	protected String getEditorName() {
 		return EDITOR_NAME;
 	}
+	
+	@Override
+	public String getEditorId() {
+		return ID;
+	}
 
 	@Override
 	protected AbstractSpotterEditorInput createEditorInput(IFile file) {
@@ -106,7 +111,7 @@ public class SpotterConfigEditor extends AbstractSpotterEditor {
 		}
 
 		propertiesGroupViewer = new PropertiesGroupViewer(parent, this);
-		IExtensionItemFactory factory = new ImmutableExtensionItemFactory();
+		IExtensionItemFactory factory = new ImmutableExtensionItemFactory(getEditorId());
 		IExtensionItem inputModel = createInputModel(editorInput.getFile(), factory);
 		if (inputModel != null) {
 			propertiesGroupViewer.updateProperties(inputModel);

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/WorkloadEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/WorkloadEditor.java
@@ -45,6 +45,11 @@ public class WorkloadEditor extends AbstractEnvironmentEditor {
 	protected String getEditorName() {
 		return EDITOR_NAME;
 	}
+	
+	@Override
+	public String getEditorId() {
+		return ID;
+	}
 
 	@Override
 	protected void applyChanges(Object xmlModelRoot) {

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/AbstractExtensionItemDecorator.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/AbstractExtensionItemDecorator.java
@@ -80,6 +80,11 @@ public abstract class AbstractExtensionItemDecorator implements IExtensionItem {
 	public Image getImage() {
 		return delegate.getImage();
 	}
+	
+	@Override
+	public String getEditorId() {
+		return delegate.getEditorId();
+	}
 
 	@Override
 	public boolean isConnectionIgnored() {

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/BasicEditorExtensionItemFactory.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/BasicEditorExtensionItemFactory.java
@@ -28,23 +28,36 @@ import org.spotter.eclipse.ui.model.xml.IModelWrapper;
  */
 public class BasicEditorExtensionItemFactory implements IExtensionItemFactory {
 
+	private final String editorId;
+
+	/**
+	 * Creates a basic extension item factory for the given editor.
+	 * 
+	 * @param editorId
+	 *            the id of the editor the created extensions will be assigned
+	 *            to
+	 */
+	public BasicEditorExtensionItemFactory(String editorId) {
+		this.editorId = editorId;
+	}
+
 	@Override
 	public IExtensionItem createExtensionItem() {
-		IExtensionItem basicItem = new ExtensionItem();
+		IExtensionItem basicItem = new ExtensionItem(editorId);
 		enhanceExtensionItem(basicItem);
 		return basicItem;
 	}
 
 	@Override
 	public IExtensionItem createExtensionItem(IModelWrapper modelWrapper) {
-		IExtensionItem basicItem = new ExtensionItem(modelWrapper);
+		IExtensionItem basicItem = new ExtensionItem(modelWrapper, editorId);
 		enhanceExtensionItem(basicItem);
 		return basicItem;
 	}
 
 	@Override
 	public IExtensionItem createExtensionItem(IExtensionItem parent, IModelWrapper modelWrapper) {
-		IExtensionItem basicItem = new ExtensionItem(parent, modelWrapper);
+		IExtensionItem basicItem = new ExtensionItem(parent, modelWrapper, editorId);
 		enhanceExtensionItem(basicItem);
 		return basicItem;
 	}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/ExtensionItem.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/ExtensionItem.java
@@ -62,6 +62,7 @@ public class ExtensionItem implements IExtensionItem {
 	private final IModelWrapper modelWrapper;
 	private final Map<String, ConfigParameterDescription> remainingDescriptions;
 
+	private final String editorId;
 	private ServiceClientWrapper client;
 	private long lastCacheClearTime;
 	private Map<String, ConfigParameterDescription> paramsMap;
@@ -73,9 +74,12 @@ public class ExtensionItem implements IExtensionItem {
 
 	/**
 	 * Creates an extension item with no children and no model.
+	 * 
+	 * @param editorId
+	 *            the id of the editor this extension is assigned to
 	 */
-	public ExtensionItem() {
-		this(null, null);
+	public ExtensionItem(String editorId) {
+		this(null, null, editorId);
 	}
 
 	/**
@@ -85,9 +89,11 @@ public class ExtensionItem implements IExtensionItem {
 	 * 
 	 * @param modelWrapper
 	 *            the model wrapper
+	 * @param editorId
+	 *            the id of the editor this extension is assigned to
 	 */
-	public ExtensionItem(IModelWrapper modelWrapper) {
-		this(null, modelWrapper);
+	public ExtensionItem(IModelWrapper modelWrapper, String editorId) {
+		this(null, modelWrapper, editorId);
 	}
 
 	/**
@@ -97,14 +103,17 @@ public class ExtensionItem implements IExtensionItem {
 	 *            the parent of this item
 	 * @param modelWrapper
 	 *            the model wrapper for this item
+	 * @param editorId
+	 *            the id of the editor this extension is assigned to
 	 */
-	public ExtensionItem(IExtensionItem parent, IModelWrapper modelWrapper) {
+	public ExtensionItem(IExtensionItem parent, IModelWrapper modelWrapper, String editorId) {
 		this.itemChangedListeners = new ArrayList<IItemChangedListener>();
 		this.propertiesChangedListeners = new ArrayList<IItemPropertiesChangedListener>();
 		this.handlerMediatorHelper = new HandlerMediatorHelper();
 		this.childrenItems = new ArrayList<IExtensionItem>();
 		this.parentItem = parent;
 
+		this.editorId = editorId;
 		this.client = null;
 		this.lastCacheClearTime = 0;
 		this.modelWrapper = modelWrapper;
@@ -170,6 +179,17 @@ public class ExtensionItem implements IExtensionItem {
 			image = connection ? IMG_CONN_AVAILABLE : IMG_CONN_UNAVAILABLE;
 		}
 		return image;
+	}
+
+	@Override
+	public String getEditorId() {
+		return editorId;
+	}
+
+	@Override
+	public String toString() {
+		String text = getText();
+		return text.isEmpty() ? "ExtensionItem {no model}" : text;
 	}
 
 	@Override

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/IExtensionItem.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/IExtensionItem.java
@@ -53,6 +53,11 @@ public interface IExtensionItem extends IHandlerMediator {
 	Image getImage();
 
 	/**
+	 * @return the id of the editor this extension is assigned to
+	 */
+	String getEditorId();
+
+	/**
 	 * @return whether the connection of this item is irrelevant and is ignored
 	 */
 	boolean isConnectionIgnored();

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/IExtensionItemFactory.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/IExtensionItemFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 SAP AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.spotter.eclipse.ui.model;
 
 import org.spotter.eclipse.ui.model.xml.IModelWrapper;

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/ImmutableExtensionItemFactory.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/ImmutableExtensionItemFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 SAP AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.spotter.eclipse.ui.model;
 
 import org.spotter.eclipse.ui.model.xml.IModelWrapper;
@@ -11,19 +26,32 @@ import org.spotter.eclipse.ui.model.xml.IModelWrapper;
  */
 public class ImmutableExtensionItemFactory implements IExtensionItemFactory {
 
+	private final String editorId;
+
+	/**
+	 * Creates a basic extension item factory for the given editor.
+	 * 
+	 * @param editorId
+	 *            the id of the editor the created extensions will be assigned
+	 *            to
+	 */
+	public ImmutableExtensionItemFactory(String editorId) {
+		this.editorId = editorId;
+	}
+
 	@Override
 	public IExtensionItem createExtensionItem() {
-		return new ExtensionItem();
+		return new ExtensionItem(editorId);
 	}
 
 	@Override
 	public IExtensionItem createExtensionItem(IModelWrapper modelWrapper) {
-		return new ExtensionItem(modelWrapper);
+		return new ExtensionItem(modelWrapper, editorId);
 	}
 
 	@Override
 	public IExtensionItem createExtensionItem(IExtensionItem parent, IModelWrapper modelWrapper) {
-		return new ExtensionItem(parent, modelWrapper);
+		return new ExtensionItem(parent, modelWrapper, editorId);
 	}
 
 }

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ActiveRunView.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ActiveRunView.java
@@ -102,7 +102,7 @@ public class ActiveRunView extends ViewPart {
 	 * The constructor.
 	 */
 	public ActiveRunView() {
-		this.extensionItemFactory = new ImmutableExtensionItemFactory();
+		this.extensionItemFactory = new ImmutableExtensionItemFactory(null);
 		this.isDisposed = false;
 		this.spotterProgress = null;
 		this.currentViewerInputJobId = 0;
@@ -139,7 +139,7 @@ public class ActiveRunView extends ViewPart {
 	}
 
 	private void createTreeViewer(Composite parent) {
-		treeViewer = ExtensionsGroupViewer.createTreeViewer(parent, extensionItemFactory.createExtensionItem());
+		treeViewer = ExtensionsGroupViewer.createTreeViewer(parent, extensionItemFactory.createExtensionItem(), false);
 
 		SpotterExtensionsLabelProvider labelProvider = new SpotterExtensionsLabelProvider() {
 			@Override

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ResultsView.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/view/ResultsView.java
@@ -137,7 +137,7 @@ public class ResultsView extends ViewPart implements ISelectionListener {
 	public ResultsView() {
 		this.client = null;
 		this.runResultItem = null;
-		this.extensionItemFactory = new ImmutableExtensionItemFactory();
+		this.extensionItemFactory = new ImmutableExtensionItemFactory(null);
 	}
 
 	@Override
@@ -286,7 +286,7 @@ public class ResultsView extends ViewPart implements ISelectionListener {
 		SashForm container = new SashForm(parent, SWT.VERTICAL | SWT.SMOOTH);
 
 		hierarchyTreeViewer = ExtensionsGroupViewer.createTreeViewer(container,
-				extensionItemFactory.createExtensionItem());
+				extensionItemFactory.createExtensionItem(), false);
 		SpotterExtensionsLabelProvider labelProvider = (SpotterExtensionsLabelProvider) hierarchyTreeViewer
 				.getLabelProvider();
 		imageProvider = new ResultExtensionsImageProvider();


### PR DESCRIPTION
Preparation for the possibility to drag and drop extensions within
editors or from one to another in order to move, copy or rearrange the
extensions.

Change-Id: I888af21a2fbe16baccbad2e7b1aa65c677229f11
Signed-off-by: Denis Knoepfle <denis.knoepfle@sap.com>