### PR TITLE
Implement external drag'n drop for extensions

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/dnd/ExtensionDragListener.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/dnd/ExtensionDragListener.java
@@ -15,12 +15,16 @@
  */
 package org.spotter.eclipse.ui.dnd;
 
+import java.util.List;
+
 import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DragSourceEvent;
 import org.eclipse.swt.dnd.DragSourceListener;
 import org.spotter.eclipse.ui.editors.AbstractExtensionsEditor;
+import org.spotter.eclipse.ui.model.IExtensionItem;
 
 /**
  * A drag listener for {@link org.spotter.eclipse.ui.model.IExtensionItem}.
@@ -34,6 +38,8 @@ public class ExtensionDragListener implements DragSourceListener {
 
 	private final StructuredViewer viewer;
 	private final AbstractExtensionsEditor editor;
+	private IExtensionItem extensionDragSource;
+	private IExtensionItem extensionDragSourceParent;
 
 	/**
 	 * Creates a new drag listener for the given viewer.
@@ -41,7 +47,7 @@ public class ExtensionDragListener implements DragSourceListener {
 	 * @param viewer
 	 *            the viewer this listener is attached to
 	 * @param editor
-	 *            the underlying editor if any or <code>null</code>
+	 *            the underlying editor
 	 */
 	public ExtensionDragListener(StructuredViewer viewer, AbstractExtensionsEditor editor) {
 		this.viewer = viewer;
@@ -50,10 +56,14 @@ public class ExtensionDragListener implements DragSourceListener {
 
 	@Override
 	public void dragStart(DragSourceEvent event) {
-		event.doit = !viewer.getSelection().isEmpty();
+		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
+		event.doit = !selection.isEmpty() && selection.getFirstElement() instanceof IExtensionItem;
 		if (event.doit) {
-			LocalSelectionTransfer.getTransfer().setSelection(viewer.getSelection());
+			extensionDragSource = (IExtensionItem) selection.getFirstElement();
+			extensionDragSourceParent = extensionDragSource.getParent();
+			LocalSelectionTransfer.getTransfer().setSelection(selection);
 			viewer.setData(VIEWER_IS_DRAG_SOURCE_PROPERTY, Boolean.TRUE);
+			viewer.setData(ExtensionDropListener.VIEWER_IS_DROP_TARGET_PROPERTY, null);
 		}
 	}
 
@@ -66,13 +76,19 @@ public class ExtensionDragListener implements DragSourceListener {
 	public void dragFinished(DragSourceEvent event) {
 		viewer.setData(VIEWER_IS_DRAG_SOURCE_PROPERTY, null);
 		boolean isDropTarget = isThisViewerDropTarget();
-		viewer.setData(ExtensionDropListener.VIEWER_IS_DROP_TARGET_PROPERTY, null);
 		if (!event.doit || event.detail == DND.DROP_NONE) {
 			return;
 		}
 
 		if (event.detail == DND.DROP_MOVE && !isDropTarget) {
-			// TODO: remove the drag source from the model
+			// remove the drag source from the model
+			List<?> targetChildren = extensionDragSource.getParent().getModelWrapper().getChildren();
+			List<?> sourceChildren = extensionDragSourceParent.getModelWrapper().getChildren();
+			// delete extension from source children
+			extensionDragSource.getModelWrapper().setXMLModelContainingList(sourceChildren);
+			extensionDragSourceParent.removeItem(extensionDragSource, false);
+			// set target children as new containing list
+			extensionDragSource.getModelWrapper().setXMLModelContainingList(targetChildren);
 			if (editor != null) {
 				editor.markDirty();
 			}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractExtensionsEditor.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/editors/AbstractExtensionsEditor.java
@@ -73,7 +73,7 @@ public abstract class AbstractExtensionsEditor extends AbstractSpotterEditor {
 	 * @return a wrapper for the given component
 	 */
 	public abstract IModelWrapper createModelWrapper(Object parent, ExtensionMetaobject extensionComponent);
-
+	
 	@Override
 	public void createPartControl(Composite parent) {
 		AbstractSpotterEditorInput editorInput = (AbstractSpotterEditorInput) getEditorInput();

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/viewers/ExtensionsGroupViewer.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/viewers/ExtensionsGroupViewer.java
@@ -112,7 +112,7 @@ public class ExtensionsGroupViewer {
 	private Control viewerControl;
 	private TableViewer extensionsTblViewer;
 	private TreeViewer extensionsTreeViewer;
-	private ColumnViewer extensionsViewer;
+	private StructuredViewer extensionsViewer;
 	private Button btnAddExtension, btnAppendExtension, btnRemoveExtension, btnRefreshExtensions;
 
 	/**
@@ -168,7 +168,7 @@ public class ExtensionsGroupViewer {
 	/**
 	 * @return the underlying viewer
 	 */
-	public ColumnViewer getViewer() {
+	public StructuredViewer getViewer() {
 		return extensionsViewer;
 	}
 


### PR DESCRIPTION
Extensions can now be moved from one project to another via drag'n drop
in the according editors.

Change-Id: I615ee93205ca0a44cf54c9cffd519d50f67fee1a
Signed-off-by: Denis Knoepfle <denis.knoepfle@sap.com>