### PR TITLE
Implement copy operation for drag'n drop of Extension Items

### DIFF
--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/AbstractExtensionItemDecorator.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/AbstractExtensionItemDecorator.java
@@ -152,6 +152,11 @@ public abstract class AbstractExtensionItemDecorator implements IExtensionItem {
 	}
 
 	@Override
+	public IExtensionItem copyItem() {
+		return delegate.copyItem();
+	}
+	
+	@Override
 	public IExtensionItem getItem(int index) {
 		return delegate.getItem(index);
 	}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/BasicEditorExtensionItemFactory.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/BasicEditorExtensionItemFactory.java
@@ -15,8 +15,6 @@
  */
 package org.spotter.eclipse.ui.model;
 
-import org.spotter.eclipse.ui.handlers.DeleteHandler;
-import org.spotter.eclipse.ui.menu.IDeletable;
 import org.spotter.eclipse.ui.model.xml.IModelWrapper;
 
 /**
@@ -63,10 +61,10 @@ public class BasicEditorExtensionItemFactory implements IExtensionItemFactory {
 	}
 
 	private void enhanceExtensionItem(IExtensionItem basicItem) {
-		addDeleteHandler(basicItem);
+		//addDeleteHandler(basicItem);
 	}
 
-	private void addDeleteHandler(IExtensionItem basicItem) {
+	/*private void addDeleteHandler(IExtensionItem basicItem) {
 		basicItem.addHandler(DeleteHandler.DELETE_COMMAND_ID, new IDeletable() {
 
 			private static final String ELEMENT_TYPE_NAME = "Extension Item";
@@ -93,6 +91,6 @@ public class BasicEditorExtensionItemFactory implements IExtensionItemFactory {
 			}
 
 		});
-	}
+	}*/
 
 }

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/IExtensionItem.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/IExtensionItem.java
@@ -158,6 +158,15 @@ public interface IExtensionItem extends IHandlerMediator {
 	void removed(boolean propagate);
 
 	/**
+	 * Returns a deep copy of this item including its children. If this item
+	 * contained any unique keys, the copy will have new keys assigned instead
+	 * to ensure that all keys remain unique.
+	 * 
+	 * @return a copy of this item
+	 */
+	IExtensionItem copyItem();
+
+	/**
 	 * Returns a specific item determined by its index.
 	 * 
 	 * @param index

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/EnvironmentModelWrapper.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/EnvironmentModelWrapper.java
@@ -36,7 +36,8 @@ public class EnvironmentModelWrapper extends AbstractModelWrapper {
 	private final List<XMeasurementEnvObject> children;
 
 	/**
-	 * Creates a new wrapper.
+	 * Creates a new wrapper without any children. Only the root wrapper
+	 * assigned to the editor input is assumed to have children.
 	 * 
 	 * @param extension
 	 *            the associated extension
@@ -54,7 +55,8 @@ public class EnvironmentModelWrapper extends AbstractModelWrapper {
 	}
 
 	/**
-	 * Creates a new wrapper.
+	 * Creates a new wrapper. This constructor only serves for the root wrapper
+	 * which will be assigned to the editor input.
 	 * 
 	 * @param children
 	 *            the children of this wrapper
@@ -76,6 +78,15 @@ public class EnvironmentModelWrapper extends AbstractModelWrapper {
 		if (wrappedModel != null) {
 			wrappedModel.setConfig(config);
 		}
+	}
+
+	@Override
+	public IModelWrapper copy() {
+		XMeasurementEnvObject modelCopy = MeasurementEnvironmentFactory.getInstance().copyMeasurementEnvObject(
+				wrappedModel);
+		EnvironmentModelWrapper wrapper = new EnvironmentModelWrapper(extension, modelContainingList, modelCopy);
+
+		return wrapper;
 	}
 
 	@Override

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/HierarchyFactory.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/HierarchyFactory.java
@@ -22,6 +22,7 @@ import javax.xml.bind.JAXBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spotter.eclipse.ui.UICoreException;
+import org.spotter.eclipse.ui.util.SpotterUtils;
 import org.spotter.shared.hierarchy.model.RawHierarchyFactory;
 import org.spotter.shared.hierarchy.model.XPerformanceProblem;
 
@@ -77,6 +78,26 @@ public final class HierarchyFactory {
 			LOGGER.error(message + " Cause: {}", e.getMessage());
 			throw new UICoreException(message, e);
 		}
+	}
+
+	/**
+	 * Copies the given performance problem. All unique keys are replaced by new
+	 * ones. Children are not copied.
+	 * 
+	 * @param problem
+	 *            the problem to copy
+	 * @return the copied problem
+	 */
+	public XPerformanceProblem copyPerformanceProblem(XPerformanceProblem problem) {
+		XPerformanceProblem copy = new XPerformanceProblem();
+		copy.setExtensionName(problem.getExtensionName());
+		copy.setUniqueId(RawHierarchyFactory.generateUniqueId());
+
+		if (problem.getConfig() != null) {
+			copy.setConfig(SpotterUtils.copyConfigurationList(problem.getConfig()));
+		}
+
+		return copy;
 	}
 
 }

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/HierarchyModelWrapper.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/HierarchyModelWrapper.java
@@ -67,6 +67,14 @@ public class HierarchyModelWrapper extends AbstractModelWrapper {
 	}
 
 	@Override
+	public IModelWrapper copy() {
+		XPerformanceProblem modelCopy = HierarchyFactory.getInstance().copyPerformanceProblem(wrappedModel);
+		HierarchyModelWrapper wrapper = new HierarchyModelWrapper(extension, modelContainingList, modelCopy);
+
+		return wrapper;
+	}
+
+	@Override
 	public Object getXMLModel() {
 		return wrappedModel;
 	}

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/IModelWrapper.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/IModelWrapper.java
@@ -46,6 +46,14 @@ public interface IModelWrapper {
 	String NAME_KEY = ConfigKeys.SATELLITE_ADAPTER_NAME_KEY;
 
 	/**
+	 * Creates a copy of this wrapper including its underlying XML model. Any
+	 * unique keys are replaced by new ones. Children should not be copied.
+	 * 
+	 * @return a copy of this wrapper
+	 */
+	IModelWrapper copy();
+
+	/**
 	 * @return the name of the extension that the model is associated with
 	 */
 	String getExtensionName();

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/MeasurementEnvironmentFactory.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/MeasurementEnvironmentFactory.java
@@ -24,6 +24,7 @@ import javax.xml.bind.JAXBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spotter.eclipse.ui.UICoreException;
+import org.spotter.eclipse.ui.util.SpotterUtils;
 import org.spotter.shared.environment.model.ObjectFactory;
 import org.spotter.shared.environment.model.XMeasurementEnvObject;
 import org.spotter.shared.environment.model.XMeasurementEnvironment;
@@ -100,6 +101,22 @@ public final class MeasurementEnvironmentFactory {
 		env.setWorkloadAdapter(workloadAdapters);
 
 		return env;
+	}
+
+	/**
+	 * Creates a copy of the given measurement environment object.
+	 * 
+	 * @param envObj
+	 *            the object to copy
+	 * @return the copy of the given object
+	 */
+	public XMeasurementEnvObject copyMeasurementEnvObject(XMeasurementEnvObject envObj) {
+		XMeasurementEnvObject envObjCopy = new XMeasurementEnvObject();
+		envObjCopy.setExtensionName(envObj.getExtensionName());
+		if (envObj.getConfig() != null) {
+			envObjCopy.setConfig(SpotterUtils.copyConfigurationList(envObj.getConfig()));
+		}
+		return envObjCopy;
 	}
 
 }

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/SpotterConfigModelWrapper.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/model/xml/SpotterConfigModelWrapper.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.lpe.common.config.ConfigParameterDescription;
 import org.spotter.eclipse.ui.Activator;
 import org.spotter.eclipse.ui.ServiceClientWrapper;
+import org.spotter.eclipse.ui.util.SpotterUtils;
 import org.spotter.shared.environment.model.XMConfiguration;
 
 /**
@@ -37,6 +38,11 @@ public class SpotterConfigModelWrapper implements IModelWrapper {
 
 	private final String projectName;
 	private List<XMConfiguration> xmConfigList;
+
+	// private constructor for copy method
+	private SpotterConfigModelWrapper(String projectName) {
+		this.projectName = projectName;
+	}
 
 	/**
 	 * Creates an instance of this class using the given properties.
@@ -80,6 +86,13 @@ public class SpotterConfigModelWrapper implements IModelWrapper {
 	@Override
 	public void setConfig(List<XMConfiguration> config) {
 		this.xmConfigList = config;
+	}
+
+	@Override
+	public IModelWrapper copy() {
+		SpotterConfigModelWrapper wrapper = new SpotterConfigModelWrapper(projectName);
+		wrapper.setConfig(SpotterUtils.copyConfigurationList(getConfig()));
+		return wrapper;
 	}
 
 	/**

--- a/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/util/SpotterUtils.java
+++ b/org.spotter.eclipse.ui/src/org/spotter/eclipse/ui/util/SpotterUtils.java
@@ -140,6 +140,26 @@ public final class SpotterUtils {
 	}
 
 	/**
+	 * Copies the configuration list.
+	 * 
+	 * @param config
+	 *            the list to copy
+	 * @return a deep copy of the list
+	 */
+	public static List<XMConfiguration> copyConfigurationList(List<XMConfiguration> config) {
+		List<XMConfiguration> configCopy = new ArrayList<>();
+		if (config != null) {
+			for (XMConfiguration xmConfig : config) {
+				XMConfiguration xmConfigCopy = new XMConfiguration();
+				xmConfigCopy.setKey(xmConfig.getKey());
+				xmConfigCopy.setValue(xmConfig.getValue());
+				configCopy.add(xmConfigCopy);
+			}
+		}
+		return configCopy;
+	}
+
+	/**
 	 * Checks whether the given list of config parameters contains the key.
 	 * 
 	 * @param config


### PR DESCRIPTION
Extension Items can now be copied within the same editor instance or
from one to another of the same type via drag'n drop. Hold down 'ctrl'
while dragging to enable copying.
If the copied extension items contained any unique keys, then they'll
have new keys assigned to ensure that all keys remain unique.

Change-Id: I814c3807af35865af7070a7a5f6d817575641d29
Signed-off-by: Denis Knoepfle <denis.knoepfle@sap.com>